### PR TITLE
fix: bump outdated reth image

### DIFF
--- a/src/expb/configs/clients/reth.py
+++ b/src/expb/configs/clients/reth.py
@@ -14,7 +14,7 @@ class RethConfig(ClientConfig):
     def __init__(self):
         super().__init__(
             name="reth",
-            default_image="ethpandaops/reth:performance",
+            default_image="paradigmxyz/reth:nightly",
             default_command=[
                 "node",
                 f"--datadir={CLIENTS_DATA_DIR}",


### PR DESCRIPTION
The Reth image being used in the PandaOps Docker was outdated and contained a known regression under load which was initially disclosed by the Rise team. This PR updates it to the [latest image](https://github.com/paradigmxyz/reth/pkgs/container/reth). 

We recommend re-running the benchmark to ensure that results are accurate!