### PR TITLE
feat: env-variable overrides for benchmark warming/caching options

### DIFF
--- a/src/expb/execute_scenarios.py
+++ b/src/expb/execute_scenarios.py
@@ -1,3 +1,4 @@
+import os
 import re
 from pathlib import Path
 
@@ -105,6 +106,12 @@ def execute_scenarios(
     Execute payloads for multiple execution clients using Grafana K6.
     """
     logger = setup_logging(log_level)
+
+    # Allow CI/automation to enable per-block EVM warmup via an environment
+    # variable, without changing the (often fixed) command-line invocation.
+    # Equivalent to passing --evm-warmup.
+    if os.environ.get("EXPB_EVM_WARMUP", "0") == "1":
+        evm_warmup = True
 
     # Use default lock file if not specified
     lock_file_path = lock_file or get_default_lock_file()

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -88,12 +88,19 @@ class Executor:
             raise e
 
     def clean_system_cache(self) -> None:
-        self.log.info("Cleaning system cache")
+        # EXPB_SKIP_DROP_CACHES keeps the OS page cache warm across runs so the
+        # read-only base-DB snapshot stays resident in RAM between runs instead
+        # of being re-read cold from disk each run. Useful for warm, lower-variance
+        # measurements; dropping all caches every run (the default) exposes
+        # cold-read service-time variance. The sync still runs to flush dirty pages.
+        skip_drop = os.environ.get("EXPB_SKIP_DROP_CACHES", "0") == "1"
+        self.log.info("Cleaning system cache", drop_caches=not skip_drop)
         try:
             subprocess.run("sync", check=True, shell=True)
-            with open("/proc/sys/vm/drop_caches", "w") as f:
-                f.write("3")
-            self.log.info("System cache cleaned")
+            if not skip_drop:
+                with open("/proc/sys/vm/drop_caches", "w") as f:
+                    f.write("3")
+            self.log.info("System cache cleaned", dropped=not skip_drop)
         except subprocess.CalledProcessError as e:
             self.log.error("Failed to clean system cache", error=e)
             raise e

--- a/src/expb/payloads/executor/executor_config.py
+++ b/src/expb/payloads/executor/executor_config.py
@@ -91,6 +91,15 @@ class ExecutorConfig:
         self.k6_warmup_wait: int = scenario.warmup_wait
         self.k6_payloads_skip: int | None = scenario.payloads_skip
         self.k6_payloads_warmup: int | None = scenario.payloads_warmup
+        # EXPB_WARMUP_OVERRIDE overrides the number of unmeasured warmup payloads
+        # without editing the scenario config. A larger warmup lets the OS page
+        # cache and client caches reach a warm steady state before measurement.
+        _warmup_override = os.environ.get("EXPB_WARMUP_OVERRIDE")
+        if _warmup_override:
+            try:
+                self.k6_payloads_warmup = int(_warmup_override)
+            except ValueError:
+                pass
 
         # Executor Directories
         ## Payloads and FCUs
@@ -189,6 +198,17 @@ class ExecutorConfig:
     def get_execution_client_env(self) -> dict[str, str]:
         env = self.execution_client.value.default_env.copy()
         env.update(self.execution_client_extra_env)
+        # EXPB_CLIENT_ENV (comma- or newline-separated KEY=VALUE) injects extra
+        # environment into the execution-client container without editing the
+        # scenario config, e.g. EXPB_CLIENT_ENV="DOTNET_gcServer=0".
+        override = os.environ.get("EXPB_CLIENT_ENV", "")
+        if override:
+            for item in override.replace("\n", ",").split(","):
+                item = item.strip()
+                if not item or "=" not in item:
+                    continue
+                key, _, value = item.partition("=")
+                env[key.strip()] = value.strip()
         return env
 
     def get_execution_client_ports(self) -> dict[str, tuple[str, str]]:


### PR DESCRIPTION
## Summary

Adds environment-variable gates so CI/automation (e.g. the Nethermind `run-expb-reproducible-benchmarks` workflow, which invokes `expb execute-scenarios` with a fixed command line) can toggle benchmark **warming/caching behavior** without changing the CLI invocation or editing the scenario config:

| Env var | Effect | Equivalent |
|---|---|---|
| `EXPB_EVM_WARMUP=1` | Per-block `eth_simulateV1` warmup before each measured payload (warms contract code, state trie, DB block cache) | `--evm-warmup` |
| `EXPB_WARMUP_OVERRIDE=N` | Override the number of unmeasured warmup payloads | scenario `warmup:` |
| `EXPB_SKIP_DROP_CACHES=1` | Keep the OS page cache warm across runs (the base-DB snapshot stays resident in RAM); `sync` still runs | — |
| `EXPB_CLIENT_ENV="K=V,..."` | Inject extra environment into the execution-client container (e.g. `DOTNET_gcServer=0`) | scenario `extra_env:` |

All default to off / no-op, so existing behavior is unchanged.

## Motivation

While investigating run-to-run variance (CV) of the flat-realblocks benchmark, the speculative prewarmer was found to keep only a **razor-thin lead** over execution at `delay=0` — so a fraction of state reads still hit cold storage, inflating both the mean and the run-to-run variance.

Enabling **`EXPB_EVM_WARMUP`** (synchronous per-block warming) is the cleanest lever: it drops **AVG ~27→22ms** and collapses the tail (**P99 ~105→50ms, MAX ~205→80ms**), roughly **halving run-to-run CV** — a faster, more stable "warm-execution" benchmark mode. These gates make that mode (and related caching knobs) selectable from the workflow via env.

The companion Nethermind workflow change that passes these env vars through is in a separate PR.

## Testing

Ran 10-run flat-realblocks dispatches on the reproducible-benchmarks runner with each gate; confirmed `EXPB_EVM_WARMUP=1` yields the lower AVG + collapsed tail described above, and all gates default to no-op (existing behavior preserved).