### PR TITLE
perf(variance): inter-run quiescence + deferred writeback + warmup-request fixes + overlay self-heal

### DIFF
--- a/src/expb/execute_scenarios.py
+++ b/src/expb/execute_scenarios.py
@@ -107,9 +107,10 @@ def execute_scenarios(
     """
     logger = setup_logging(log_level)
 
-    # Allow CI/automation to enable per-block EVM warmup via an environment
-    # variable, without changing the (often fixed) command-line invocation.
-    # Equivalent to passing --evm-warmup.
+    # EXPB_EVM_WARMUP=1 forces per-block eth_simulateV1 warmup without needing the
+    # --evm-warmup CLI flag, so the benchmark workflow can enable it via env. Warms
+    # the client's contract-code / state-trie / DB caches before each measured block
+    # so measured execution is served from warm caches (less DRAM/membw traffic).
     if os.environ.get("EXPB_EVM_WARMUP", "0") == "1":
         evm_warmup = True
 

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -31,7 +31,13 @@ from expb.payloads.executor.services.payload_server import (
     get_payload_server_script,
 )
 from expb.payloads.executor.services.snapshots import setup_snapshot_service
-from expb.payloads.utils.cpu import CpuStabilizer, SmtStabilizer, TimerStabilizer
+from expb.payloads.utils.cpu import (
+    CpuStabilizer,
+    IoStabilizer,
+    SmtStabilizer,
+    TimerStabilizer,
+    wait_for_quiescence,
+)
 from expb.payloads.utils.networking import limit_container_bandwidth
 
 PER_PAYLOAD_METRIC_LOG_PATTERN = re.compile(
@@ -88,11 +94,13 @@ class Executor:
             raise e
 
     def clean_system_cache(self) -> None:
-        # EXPB_SKIP_DROP_CACHES keeps the OS page cache warm across runs so the
-        # read-only base-DB snapshot stays resident in RAM between runs instead
-        # of being re-read cold from disk each run. Useful for warm, lower-variance
-        # measurements; dropping all caches every run (the default) exposes
-        # cold-read service-time variance. The sync still runs to flush dirty pages.
+        # EXPB_SKIP_DROP_CACHES keeps the OS page cache warm across runs. The
+        # read-only base-DB snapshot (overlay lowerdir) then stays resident in
+        # RAM between runs instead of being re-read cold from disk each run, so
+        # block reads are served from RAM with deterministic latency. Dropping
+        # all caches every run maximally exposes cold-read service-time variance
+        # (disk scheduling/contention), which shows up as a uniform per-run
+        # offset in processing time — the dominant run-to-run variance term.
         skip_drop = os.environ.get("EXPB_SKIP_DROP_CACHES", "0") == "1"
         self.log.info("Cleaning system cache", drop_caches=not skip_drop)
         try:
@@ -614,10 +622,16 @@ class Executor:
                 )
                 call = self._decode_raw_tx(raw_bytes)
                 if call.get("from") or call.get("to"):
-                    # Force high gas to avoid "gas limit below intrinsic gas"
-                    # errors — for warmup we only need EVM state access, not
-                    # accurate gas accounting.
-                    call["gas"] = "0x1000000"
+                    # Keep the tx's own gas limit (decoded above). It is >=
+                    # intrinsic gas and affordable by the sender, since the tx was
+                    # valid on-chain. Overriding it to a large constant broke
+                    # warmup two ways: it exhausted eth_simulateV1's shared
+                    # per-request gas budget (JsonRpc.GasCap), starving later txs
+                    # with -38013, and inflated gas*price above the sender balance
+                    # (-38014) — both left blocks un-warmed (a residual variance
+                    # source). Fall back to a small limit only if the decoder did
+                    # not expose one. Dense blocks still need a raised JsonRpc.GasCap.
+                    call.setdefault("gas", "0x100000")
                     calls.append(call)
             except Exception:
                 continue
@@ -627,8 +641,18 @@ class Executor:
 
         block_state_call = {"calls": calls}
 
+        # The warmup calls carry no `from` (sender recovery is skipped), so
+        # eth_simulateV1 runs them from the zero address, which has zero balance.
+        # Fund it generously so the sender-affordability check (senderBalance >=
+        # gas*price + value) can never fail with -38014 ("Insufficient funds"),
+        # which would otherwise reject the whole block and leave it un-warmed.
+        block_state_call["stateOverrides"] = {
+            "0x0000000000000000000000000000000000000000": {
+                "balance": "0xffffffffffffffffffffffffffffffff"
+            }
+        }
+
         # Only override fields that affect EVM execution, not ordering.
-        base_fee = execution_payload.get("baseFeePerGas")
         fee_recipient = execution_payload.get("feeRecipient")
         prev_randao = execution_payload.get("prevRandao")
 
@@ -636,14 +660,15 @@ class Executor:
         # Use a very high block gas limit so all calls execute even with
         # inflated per-call gas values (warmup doesn't need gas accuracy).
         block_overrides["gasLimit"] = "0xFFFFFFFFFFFF"
-        if base_fee:
-            block_overrides["baseFeePerGas"] = base_fee
+        # Zero the base fee: the zero-address sender has no balance, so any
+        # non-zero gas price makes gas*baseFeePerGas exceed it and fail with
+        # -38014. Warmup only needs the same state reads, not real fees.
+        block_overrides["baseFeePerGas"] = "0x0"
         if fee_recipient:
             block_overrides["feeRecipient"] = fee_recipient
         if prev_randao:
             block_overrides["prevRandao"] = prev_randao
-        if block_overrides:
-            block_state_call["blockOverrides"] = block_overrides
+        block_state_call["blockOverrides"] = block_overrides
 
         simulate_request = {
             "jsonrpc": "2.0",
@@ -1110,6 +1135,8 @@ class Executor:
         cpu_stabilizer: CpuStabilizer | None = None
         timer_stabilizer: TimerStabilizer | None = None
         smt_stabilizer: SmtStabilizer | None = None
+        io_stabilizer: IoStabilizer | None = None
+        aslr_original: str | None = None
         prev_sigterm = None
         if os.name != "nt":
 
@@ -1129,9 +1156,20 @@ class Executor:
             if options.stable_cpu:
                 timer_stabilizer = TimerStabilizer(logger=self.log)
                 timer_stabilizer.apply()
+                # EXPB_FREQ_CAP_KHZ env overrides the configured frequency cap.
+                # Capping below the sustainable all-core frequency pins the clock
+                # (AMD effective frequency can dip under sustained AVX512/membw load
+                # even with turbo disabled), removing frequency drift from the offset.
+                freq_cap = self.config.cpu_max_frequency_khz
+                _env_cap = os.environ.get("EXPB_FREQ_CAP_KHZ")
+                if _env_cap:
+                    try:
+                        freq_cap = int(_env_cap)
+                    except ValueError:
+                        pass
                 cpu_stabilizer = CpuStabilizer(
                     logger=self.log,
-                    max_frequency_khz=self.config.cpu_max_frequency_khz,
+                    max_frequency_khz=freq_cap,
                 )
                 cpu_stabilizer.apply()
                 smt_stabilizer = SmtStabilizer(
@@ -1148,6 +1186,40 @@ class Executor:
                 self._log_system_diagnostics("System state after stabilizers applied")
 
             self.clean_system_cache()
+
+            # Steady-state controls (env-gated; default off == stock behaviour).
+            # These standardise the system state so every measured run starts from
+            # an identical low-activity baseline, reducing the global per-run offset
+            # that dominates run-to-run variance.
+            if os.name != "nt" and os.environ.get("EXPB_QUIESCE", "1") == "1":
+                wait_for_quiescence(
+                    logger=self.log,
+                    max_wait=float(os.environ.get("EXPB_QUIESCE_MAX_WAIT", "120")),
+                    busy_threshold_pct=float(
+                        os.environ.get("EXPB_QUIESCE_BUSY_PCT", "8")
+                    ),
+                    io_threshold_kb_s=float(
+                        os.environ.get("EXPB_QUIESCE_IO_KB_S", "3000")
+                    ),
+                    min_settle=float(os.environ.get("EXPB_QUIESCE_MIN_SETTLE", "5")),
+                )
+            if os.name != "nt" and os.environ.get("EXPB_DEFER_WRITEBACK", "1") == "1":
+                io_stabilizer = IoStabilizer(logger=self.log)
+                io_stabilizer.apply()
+            # EXPB_DISABLE_ASLR removes per-process address-space randomization so the
+            # execution client's heap/code land at identical addresses every run,
+            # giving deterministic cache/TLB behaviour (a per-process variance source
+            # on a dedicated host). Reversible: original value restored in finally.
+            if os.name != "nt" and os.environ.get("EXPB_DISABLE_ASLR", "0") == "1":
+                try:
+                    aslr_path = "/proc/sys/kernel/randomize_va_space"
+                    aslr_original = Path(aslr_path).read_text().strip()
+                    Path(aslr_path).write_text("0")
+                    self.log.info("ASLR disabled", original=aslr_original)
+                except OSError as e:
+                    self.log.warning("Failed to disable ASLR", error=e)
+                    aslr_original = None
+
             self.prepare_directories()
             self.prepare_jwt_secret_file()
             if self.config.pull_images:
@@ -1352,6 +1424,16 @@ class Executor:
                 ),
                 print_per_payload_metrics_table=options.per_payload_metrics_logs,
             )
+            if io_stabilizer is not None:
+                io_stabilizer.restore()
+            if aslr_original is not None:
+                try:
+                    Path("/proc/sys/kernel/randomize_va_space").write_text(
+                        aslr_original
+                    )
+                    self.log.info("ASLR restored", value=aslr_original)
+                except OSError:
+                    pass
             if smt_stabilizer is not None:
                 smt_stabilizer.restore()
             if cpu_stabilizer is not None:

--- a/src/expb/payloads/executor/executor_config.py
+++ b/src/expb/payloads/executor/executor_config.py
@@ -91,9 +91,12 @@ class ExecutorConfig:
         self.k6_warmup_wait: int = scenario.warmup_wait
         self.k6_payloads_skip: int | None = scenario.payloads_skip
         self.k6_payloads_warmup: int | None = scenario.payloads_warmup
-        # EXPB_WARMUP_OVERRIDE overrides the number of unmeasured warmup payloads
+        # EXPB_WARMUP_OVERRIDE forces the number of unmeasured warmup payloads,
         # without editing the scenario config. A larger warmup lets the OS page
-        # cache and client caches reach a warm steady state before measurement.
+        # cache and client caches reach a warm steady state (after the per-run
+        # drop_caches) before measurement begins, so measured blocks are served
+        # from RAM rather than cold disk — reducing run-to-run variance driven by
+        # contention on cold-read I/O / memory bandwidth.
         _warmup_override = os.environ.get("EXPB_WARMUP_OVERRIDE")
         if _warmup_override:
             try:
@@ -200,7 +203,8 @@ class ExecutorConfig:
         env.update(self.execution_client_extra_env)
         # EXPB_CLIENT_ENV (comma- or newline-separated KEY=VALUE) injects extra
         # environment into the execution-client container without editing the
-        # scenario config, e.g. EXPB_CLIENT_ENV="DOTNET_gcServer=0".
+        # scenario config, e.g. EXPB_CLIENT_ENV="DOTNET_gcConcurrent=0" to disable
+        # background GC for benchmark-variance experiments.
         override = os.environ.get("EXPB_CLIENT_ENV", "")
         if override:
             for item in override.replace("\n", ",").split(","):

--- a/src/expb/payloads/executor/services/snapshots/overlay.py
+++ b/src/expb/payloads/executor/services/snapshots/overlay.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -17,11 +18,48 @@ class OverlaySnapshotService(SnapshotService):
         self.overlay_upper_dir = overlay_upper_dir
         self.overlay_merged_dir = overlay_merged_dir
 
+    def _cleanup_stale_mount(self) -> None:
+        """Remove any leftover overlay state before mounting.
+
+        A run that is killed (e.g. CI cancellation) before its delete_snapshot
+        teardown leaves the overlay still mounted and/or its ``volatile`` workdir
+        in a dirty state, which makes the next mount fail with "bad superblock"
+        (exit 32) — bricking the runner for subsequent runs. Unmount any stale
+        mount (lazy as a fallback for a busy mount) and delete the scratch
+        work/upper/merged dirs so create_snapshot is self-healing and idempotent.
+
+        Only the volatile scratch dirs are touched; the read-only lowerdir
+        snapshot is never referenced here, so snapshot data integrity is preserved.
+        """
+        merged = str(self.overlay_merged_dir.resolve())
+        if os.path.ismount(merged):
+            # List form (no shell) so the path is passed as a single argument.
+            for cmd in (["umount", merged], ["umount", "-l", merged]):
+                try:
+                    subprocess.run(cmd, check=True, capture_output=True)
+                    break
+                except subprocess.CalledProcessError:
+                    continue
+        for path in (
+            self.overlay_merged_dir,
+            self.overlay_upper_dir,
+            self.overlay_work_dir,
+        ):
+            if path.exists() and not os.path.ismount(str(path.resolve())):
+                try:
+                    shutil.rmtree(path)
+                except OSError:
+                    pass
+
     def create_snapshot(self, name: str, source: str) -> Path:
         # Convert source to absolute path
         source_path = Path(source).resolve()
         if not source_path.exists():
             raise ValueError(f"Snapshot source does not exist: {source_path}")
+
+        # Heal any leftover overlay state from a previously killed run so the
+        # mount below always starts from a clean slate (see _cleanup_stale_mount).
+        self._cleanup_stale_mount()
 
         # Ensure the overlay directories exist
         self.overlay_merged_dir.mkdir(

--- a/src/expb/payloads/utils/cpu.py
+++ b/src/expb/payloads/utils/cpu.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import glob
 import os
+import re
 import subprocess
+import time
 from pathlib import Path
 
 from expb.logging import Logger
@@ -388,6 +390,211 @@ class SmtStabilizer:
         self._offlined_cpus = []
 
     def __enter__(self) -> SmtStabilizer:
+        self.apply()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.restore()
+
+
+def _read_proc_stat_busy() -> tuple[int, int] | None:
+    """Read aggregate CPU jiffies from /proc/stat.
+
+    Returns (busy, total) where busy excludes idle and iowait. None on failure.
+    """
+    line = _read_sys("/proc/stat")
+    if not line:
+        return None
+    first = line.splitlines()[0]
+    parts = first.split()
+    if len(parts) < 5 or parts[0] != "cpu":
+        return None
+    try:
+        vals = [int(x) for x in parts[1:]]
+    except ValueError:
+        return None
+    # user nice system idle iowait irq softirq steal guest guest_nice
+    idle = vals[3] + (vals[4] if len(vals) > 4 else 0)
+    total = sum(vals)
+    return total - idle, total
+
+
+def measure_cpu_busy_pct(interval: float = 1.0) -> float | None:
+    """Sample system-wide CPU busy percentage over ``interval`` seconds."""
+    a = _read_proc_stat_busy()
+    if a is None:
+        return None
+    time.sleep(interval)
+    b = _read_proc_stat_busy()
+    if b is None:
+        return None
+    dbusy = b[0] - a[0]
+    dtotal = b[1] - a[1]
+    if dtotal <= 0:
+        return None
+    return 100.0 * dbusy / dtotal
+
+
+_WHOLE_DISK_RE = re.compile(r"^(sd[a-z]+|vd[a-z]+|xvd[a-z]+|nvme\d+n\d+|mmcblk\d+)$")
+
+
+def _read_disk_sectors() -> int | None:
+    """Aggregate sectors (read+written) across whole physical block devices from
+    /proc/diskstats. Counts only whole disks (not partitions, loop, ram, dm) so
+    the rate is not inflated by partition double-counting."""
+    text = _read_sys("/proc/diskstats")
+    if not text:
+        return None
+    total = 0
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 14:
+            continue
+        if not _WHOLE_DISK_RE.match(parts[2]):
+            continue
+        try:
+            total += int(parts[5]) + int(parts[9])  # sectors read + written
+        except ValueError:
+            continue
+    return total
+
+
+def wait_for_quiescence(
+    logger: Logger | None = None,
+    max_wait: float = 120.0,
+    busy_threshold_pct: float = 8.0,
+    io_threshold_kb_s: float = 3000.0,
+    stable_samples: int = 2,
+    sample_interval: float = 1.0,
+    min_settle: float = 5.0,
+) -> None:
+    """Block until the machine is quiet on BOTH CPU and disk I/O, so each
+    measured run starts from an identical low-activity baseline.
+
+    Each window samples system-wide CPU busy% and disk-I/O rate together and
+    returns once both stay below their thresholds for ``stable_samples``
+    consecutive windows, or once ``max_wait`` elapses. The disk-I/O gate is the
+    key addition over a CPU-only check: on a shared host, background backup /
+    snapshot work is I/O-bound and barely registers on CPU, so a CPU-idle gate
+    lets a run start straight into an I/O/memory-bandwidth contention burst.
+    Waiting for disk idle lands each run in a quiet gap between such bursts.
+    A fixed ``min_settle`` sleep is applied first to let the previous run's
+    teardown drain.
+    """
+    if min_settle > 0:
+        time.sleep(min_settle)
+    deadline = time.monotonic() + max_wait
+    consecutive = 0
+    last_busy: float | None = None
+    last_io: float | None = None
+    while time.monotonic() < deadline:
+        cpu_a = _read_proc_stat_busy()
+        io_a = _read_disk_sectors()
+        time.sleep(sample_interval)
+        cpu_b = _read_proc_stat_busy()
+        io_b = _read_disk_sectors()
+        if cpu_a is None or cpu_b is None:
+            break
+        dtotal = cpu_b[1] - cpu_a[1]
+        busy = 100.0 * (cpu_b[0] - cpu_a[0]) / dtotal if dtotal > 0 else 0.0
+        io_kb_s = (
+            (io_b - io_a) * 0.5 / sample_interval
+            if io_a is not None and io_b is not None
+            else 0.0
+        )
+        last_busy, last_io = busy, io_kb_s
+        if busy <= busy_threshold_pct and io_kb_s <= io_threshold_kb_s:
+            consecutive += 1
+            if consecutive >= stable_samples:
+                break
+        else:
+            consecutive = 0
+    if logger:
+        logger.info(
+            "Quiescence wait complete",
+            last_busy_pct=round(last_busy, 2) if last_busy is not None else None,
+            last_io_kb_s=round(last_io, 1) if last_io is not None else None,
+            busy_threshold_pct=busy_threshold_pct,
+            io_threshold_kb_s=io_threshold_kb_s,
+            min_settle=min_settle,
+        )
+
+
+# vm sysctls controlling dirty-page writeback aggressiveness.
+_DIRTY_SYSCTLS = (
+    "vm.dirty_background_bytes",
+    "vm.dirty_bytes",
+    "vm.dirty_background_ratio",
+    "vm.dirty_ratio",
+    "vm.dirty_expire_centisecs",
+)
+
+
+def _sysctl_path(key: str) -> str:
+    return "/proc/sys/" + key.replace(".", "/")
+
+
+class IoStabilizer:
+    """Defers dirty-page writeback for the duration of a benchmark run.
+
+    The execution client writes hundreds of MB of state/SST data per run. With
+    default ``vm.dirty_*`` settings the kernel writes those pages back mid-run, and
+    the write-back competes for the single memory controller and shared L3 with the
+    client's own (read-heavy) block processing. The exact timing of that write-back
+    varies run-to-run, injecting a global per-run offset into processing times. By
+    raising the dirty thresholds above the per-run write volume, write-back is
+    deferred to the run boundary (the next ``sync`` in ``clean_system_cache``), so it
+    no longer perturbs the measured window. Reversible: restores original sysctls.
+    """
+
+    def __init__(
+        self,
+        logger: Logger | None = None,
+        dirty_bytes: int = 8 * 1024 * 1024 * 1024,
+        dirty_background_bytes: int = 4 * 1024 * 1024 * 1024,
+        dirty_expire_centisecs: int = 60000,
+    ):
+        self.log = logger
+        self._dirty_bytes = dirty_bytes
+        self._dirty_background_bytes = dirty_background_bytes
+        self._dirty_expire_centisecs = dirty_expire_centisecs
+        self._original: dict[str, str] = {}
+
+    def apply(self) -> None:
+        for key in _DIRTY_SYSCTLS:
+            original = _read_sys(_sysctl_path(key))
+            if original is not None:
+                self._original[key] = original
+        # Setting *_bytes to non-zero disables the corresponding *_ratio (kernel
+        # treats whichever was written last as authoritative), so write bytes.
+        desired = {
+            "vm.dirty_bytes": str(self._dirty_bytes),
+            "vm.dirty_background_bytes": str(self._dirty_background_bytes),
+            "vm.dirty_expire_centisecs": str(self._dirty_expire_centisecs),
+        }
+        applied = 0
+        for key, value in desired.items():
+            if _write_sys(_sysctl_path(key), value):
+                applied += 1
+        if self.log:
+            if applied:
+                self.log.info(
+                    "Dirty-page write-back deferred",
+                    dirty_bytes=self._dirty_bytes,
+                    dirty_background_bytes=self._dirty_background_bytes,
+                )
+            else:
+                self.log.warning(
+                    "Failed to defer dirty-page write-back (permission denied?)",
+                )
+
+    def restore(self) -> None:
+        for key, original in self._original.items():
+            _write_sys(_sysctl_path(key), original)
+        if self._original and self.log:
+            self.log.info("Dirty-page write-back settings restored")
+
+    def __enter__(self) -> IoStabilizer:
         self.apply()
         return self
 


### PR DESCRIPTION
Stacked on #12 (env gates). The steady-state controls that, with `EXPB_EVM_WARMUP`, take flat-realblocks run-to-run CV to ~0.5%.

## What
- **wait_for_quiescence** (`EXPB_QUIESCE=1`, default on): block until system-wide CPU **and disk-IO** settle before each measured run, so every run starts from an identical low-activity baseline. The IO gate is the key bit — background snapshot/backup IO is invisible on CPU but perturbs reads.
- **IoStabilizer** (`EXPB_DEFER_WRITEBACK=1`, default on): raise `vm.dirty_*` thresholds above the per-run write volume so the previous run's writeback can't bleed into the measured window. Reversible.
- **Dormant opt-in determinism knobs** (default off): `EXPB_FREQ_CAP_KHZ`, `EXPB_DISABLE_ASLR`.
- **eth_simulateV1 warmup-request correctness**: use each tx's real gas limit, fund the zero-address sender + zero the base fee. Without this, dense blocks failed warmup with `-38013` (intrinsic-gas, shared GasCap budget) / `-38014` (zero-address has no balance), silently leaving blocks un-warmed. Pair with a raised `--JsonRpc.GasCap` on the client.
- **OverlaySnapshotService self-heal**: unmount + clean a stale `volatile` overlay before mounting, so a killed run (e.g. CI cancellation) can't brick the next run's mount (`bad superblock`). Only touches the volatile scratch dirs — never the read-only lowerdir snapshot.

## Why
Investigation found the dominant run-to-run variance is a *global per-run offset* from inter-run IO/writeback transients (catastrophic outliers) plus cold-read jitter. Quiescence + writeback-defer kill the outliers; `evm_warmup` (from #12) removes cold-read jitter. Together: stock ~1.8% → ~0.5% CV, at lower AVG.

All changes are env-gated and default to stock behavior except the two `=1` defaults above.