### PR TITLE
fix: accept all Docker-style memory limits in convert_mem_limit_to_bytes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,5 @@ packages = ["src/expb"]
 [dependency-groups]
 dev = [
     "hatchling>=1.29.0",
+    "pytest>=8.0.0",
 ]

--- a/src/expb/payloads/compressor/utils.py
+++ b/src/expb/payloads/compressor/utils.py
@@ -1,11 +1,55 @@
+import math
+
+# 1024-based unit multipliers, matching how Docker parses memory limits
+# (docker-py's ``docker.utils.parse_bytes``). Keeping the same semantics means a
+# limit Docker accepts for the container is also accepted here when the value is
+# converted for the Nethermind memory hint.
+_UNIT_MULTIPLIERS = {
+    "b": 1,
+    "k": 1024,
+    "m": 1024**2,
+    "g": 1024**3,
+}
+
+
 def convert_mem_limit_to_bytes(mem_limit: str) -> int:
-    if mem_limit.endswith("g"):
-        return int(mem_limit.replace("g", "")) * 1024 * 1024 * 1024
-    elif mem_limit.endswith("m"):
-        return int(mem_limit.replace("m", "")) * 1024 * 1024
-    elif mem_limit.endswith("k"):
-        return int(mem_limit.replace("k", "")) * 1024
-    elif mem_limit.endswith("b"):
-        return int(mem_limit.replace("b", ""))
+    """Convert a Docker-style memory-limit string to a number of bytes.
+
+    Accepts the same forms Docker does, case-insensitively: a number with an
+    optional ``b``/``k``/``m``/``g`` unit (also written as the two-letter
+    ``kb``/``mb``/``gb``), or a bare byte count. Units are 1024-based. Examples:
+    ``"32g"``, ``"512M"``, ``"1gb"``, ``"1024k"``, ``"1048576"``.
+
+    The previous implementation only handled lowercase single-letter units and
+    used ``str.replace``, so valid Docker values such as ``"8G"``, ``"1gb"`` or a
+    bare byte count raised ``ValueError`` even though ``compressor.py`` passes the
+    very same string straight to Docker for the container's ``mem_limit``.
+
+    Raises:
+        ValueError: if ``mem_limit`` is empty, negative, not a finite number, or
+            uses an unrecognised unit.
+    """
+    raw = mem_limit.strip().lower()
+    if not raw:
+        raise ValueError("Memory limit is empty")
+
+    # Normalise a two-letter unit (kb/mb/gb) to its single-letter form; a lone
+    # trailing "b" is the bytes unit and is handled below.
+    if len(raw) >= 2 and raw.endswith("b") and raw[-2] in _UNIT_MULTIPLIERS:
+        raw = raw[:-1]
+
+    if raw[-1] in _UNIT_MULTIPLIERS:
+        unit, number = raw[-1], raw[:-1]
     else:
-        raise ValueError(f"Invalid memory limit: {mem_limit}")
+        unit, number = "b", raw
+
+    try:
+        value = float(number)
+    except ValueError:
+        raise ValueError(f"Invalid memory limit: {mem_limit!r}") from None
+    if not math.isfinite(value):
+        raise ValueError(f"Memory limit must be a finite number: {mem_limit!r}")
+    if value < 0:
+        raise ValueError(f"Memory limit cannot be negative: {mem_limit!r}")
+
+    return int(value * _UNIT_MULTIPLIERS[unit])

--- a/tests/test_mem_limit.py
+++ b/tests/test_mem_limit.py
@@ -1,0 +1,55 @@
+import pytest
+
+from expb.payloads.compressor.utils import convert_mem_limit_to_bytes
+
+KIB = 1024
+MIB = 1024**2
+GIB = 1024**3
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # lowercase single-letter units (already worked)
+        ("32g", 32 * GIB),  # the CLI default
+        ("8g", 8 * GIB),
+        ("512m", 512 * MIB),
+        ("1024k", 1024 * KIB),
+        ("1b", 1),
+        # uppercase units (previously raised ValueError)
+        ("8G", 8 * GIB),
+        ("512M", 512 * MIB),
+        ("1G", 1 * GIB),
+        # two-letter units (previously raised ValueError)
+        ("1gb", 1 * GIB),
+        ("1GB", 1 * GIB),
+        ("512mb", 512 * MIB),
+        ("1024kb", 1024 * KIB),
+        # bare byte counts (previously raised ValueError)
+        ("1048576", 1048576),
+        ("0", 0),
+        # surrounding whitespace (previously raised ValueError)
+        (" 8g ", 8 * GIB),
+        # fractional values, as Docker accepts
+        ("1.5g", int(1.5 * GIB)),
+    ],
+)
+def test_valid_mem_limits(value: str, expected: int) -> None:
+    assert convert_mem_limit_to_bytes(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value", ["", "   ", "abc", "-1g", "g", "1t", "1kib", "12x", "inf", "nan", "1e400"]
+)
+def test_invalid_mem_limits_raise(value: str) -> None:
+    with pytest.raises(ValueError):
+        convert_mem_limit_to_bytes(value)
+
+
+def test_matches_docker_parse_bytes_for_configurable_values() -> None:
+    # compressor.py passes the same string to docker-py for the container's
+    # mem_limit, so the two parsers must agree on every value a user would
+    # realistically configure.
+    parse_bytes = pytest.importorskip("docker.utils").parse_bytes
+    for value in ["32g", "8G", "512M", "1g", "1gb", "1GB", "1024k", "2G", "1048576"]:
+        assert convert_mem_limit_to_bytes(value) == parse_bytes(value)


### PR DESCRIPTION
**Problem.** `convert_mem_limit_to_bytes` only handled lowercase single-letter units and used `str.replace`, so valid Docker memory limits raised `ValueError`: `8G`, `512M`, `1gb`, or a bare byte count all failed. The same `mem_limit` string is passed straight to Docker for the container limit in `compressor.py` (docker-py's `parse_bytes` accepts all of those), so a user could set `--mem-limit 8G`, Docker would take it for the container, and the memory-hint conversion would crash on the same value.

**Fix.** Parse it the way Docker does (case-insensitive, 1024-based): a number with an optional `b`/`k`/`m`/`g` unit (also written `kb`/`mb`/`gb`) or a bare byte count; clear `ValueError` on invalid input (empty, negative, non-finite, or unrecognised unit).

**Tests / CI.** `CLAUDE.md` already documents a `pytest` / `tests/` workflow, but the repo had no `tests/` directory and `pytest` was not in the dev group, so the documented `pytest` command did not work out of the box. This adds the first test module for the parser (valid + invalid cases, and a check that it agrees with docker-py's `parse_bytes` on configurable values), appends `pytest` to the existing dev group, and a small GitHub Actions workflow that runs the documented command on PRs (`uv sync --dev` + `uv run pytest`).

If a reviewer prefers, the CI workflow can be split into a follow-up PR.
