### PR TITLE
fix: report the forkchoice file path in its own "already exists" error

### DIFF
--- a/src/expb/payloads/compressor/compressor.py
+++ b/src/expb/payloads/compressor/compressor.py
@@ -69,7 +69,7 @@ class Compressor:
         self._output_fcus_file = output_payloads_dir / "fcus.jsonl"
         if self._output_fcus_file.exists():
             raise ValueError(
-                f"Output forkchoice file already exists: {self._output_payloads_file}"
+                f"Output forkchoice file already exists: {self._output_fcus_file}"
             )
 
         # Nethermind docker


### PR DESCRIPTION
The "output already exists" guard for the forkchoice-update file reports the wrong path: it interpolates `self._output_payloads_file` instead of `self._output_fcus_file`, so when `fcus.jsonl` already exists the error points the user at the payloads file. One-line fix to name the file the check actually guards.
