### PR TITLE
Enable dotTrace API mode when per-block profiling is requested

### DIFF
--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -376,12 +376,20 @@ class Executor:
                 raise ValueError(
                     "dotTrace requires entrypoint to be set on the client config"
                 )
+            # Per-block snapshots are driven by MeasureProfiler API calls from inside the
+            # client (NETHERMIND_PROFILE_BLOCKS); dotTrace ignores those calls unless the
+            # session runs in API mode. Whole-run profiling must NOT set --use-api, as API
+            # mode suppresses the automatic collection window.
+            use_api = bool(
+                (execution_container_environment or {}).get("NETHERMIND_PROFILE_BLOCKS")
+            )
             dottrace_entrypoint = [
                 f"{self._DOTTRACE_CONTAINER_PATH}/dottrace",
                 "start",
                 "--framework=NetCore",
                 f"--save-to={snapshot_file}",
                 "--propagate-exit-code",
+                *(["--use-api"] if use_api else []),
                 "--",
                 client_binary,
             ]


### PR DESCRIPTION
MeasureProfiler API calls from inside the client (driven by `NETHERMIND_PROFILE_BLOCKS`, see NethermindEth/nethermind#12444) are ignored unless the dotTrace session is started with `--use-api` ([JetBrains docs](https://www.jetbrains.com/help/profiler/Profiling_Guidelines__Advanced_Profiling_Using_dotTrace_API.html)) — targeted runs therefore produced only the final whole-run snapshot.

This adds `--use-api` to the dotTrace launcher exactly when the execution container environment carries `NETHERMIND_PROFILE_BLOCKS`. Whole-run profiling is unchanged: API mode would suppress the automatic collection window, so the flag must stay conditional.

Raised by review on NethermindEth/nethermind#12444 (per-block dotTrace snapshots).