### PR TITLE
fix: warn that tc bandwidth shaping is only one-directional (#15)

### DIFF
--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -1554,6 +1554,7 @@ class Executor:
                         execution_client_container,
                         self.config.resources.download_speed,
                         self.config.resources.upload_speed,
+                        logger=self.log,
                     )
                 except Exception as e:
                     self.log.error("Failed to limit container bandwidth", error=e)

--- a/src/expb/payloads/utils/networking.py
+++ b/src/expb/payloads/utils/networking.py
@@ -2,6 +2,8 @@ import subprocess
 
 from docker.models.containers import Container
 
+from expb.logging import Logger
+
 
 def get_veth_name(pid: int) -> str:
     # This command finds the veth interface on the host for the container's eth0
@@ -17,8 +19,18 @@ def apply_tc_limits(
     veth_name: str,
     download_speed: str,
     upload_speed: str,
+    logger: Logger | None = None,
 ):
-    # FIXME: current implementation only limits egress speed (uploading)
+    # only the root (egress) qdisc is set below, not ingress (needs an IFB
+    # device, #15), so shaping is one-directional. warn about it.
+    if logger is not None:
+        logger.warning(
+            "bandwidth is shaped on the veth egress only, not ingress (needs an "
+            "IFB device), so download_speed/upload_speed are not enforced in both "
+            "directions (#15)",
+            download_speed=download_speed,
+            upload_speed=upload_speed,
+        )
     device_name = veth_name.split("@")[0]
     # Remove any existing qdisc
     subprocess.run(
@@ -50,11 +62,12 @@ def limit_container_bandwidth(
     container: Container,
     download_speed: str,
     upload_speed: str,
+    logger: Logger | None = None,
 ) -> None:
     container.reload()
     if container.attrs is not None:
         container_pid = container.attrs["State"]["Pid"]
         veth_name = get_veth_name(container_pid)
-        apply_tc_limits(veth_name, download_speed, upload_speed)
+        apply_tc_limits(veth_name, download_speed, upload_speed, logger)
     else:
         raise ValueError("Container attributes are not available")

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock, patch
+
+from expb.payloads.utils.networking import apply_tc_limits
+
+
+@patch("expb.payloads.utils.networking.subprocess.run")
+def test_apply_tc_limits_warns_shaping_one_directional(mock_run: MagicMock) -> None:
+    # only egress is shaped, not ingress (#15) - warn, don't silently mislead
+    logger = MagicMock()
+    apply_tc_limits("veth0@if4", "50mbit", "60mbit", logger=logger)
+
+    logger.warning.assert_called_once()
+    msg = logger.warning.call_args.args[0]
+    assert "download_speed" in msg
+    assert "not enforced" in msg
+    assert mock_run.called  # egress qdisc/classes still applied
+
+
+@patch("expb.payloads.utils.networking.subprocess.run")
+def test_apply_tc_limits_without_logger_is_silent(mock_run: MagicMock) -> None:
+    # no logger -> no warn, no crash
+    apply_tc_limits("veth0@if4", "50mbit", "60mbit")
+    assert mock_run.called


### PR DESCRIPTION
Addresses #15.

`apply_tc_limits` only configures the veth's root (egress) qdisc, never its ingress, so bandwidth shaping is one-directional and a configured `download_speed` / `upload_speed` is not enforced in both directions. Right now that happens silently. This threads the executor's logger through `limit_container_bandwidth` -> `apply_tc_limits` and warns when the limits are applied, so a bandwidth-constrained run isn't silently misread as fully limited.

Real bidirectional shaping (ingress via an IFB device) is a larger change and left as a follow-up; this just makes the current limitation visible.

Added `tests/test_networking.py` (mocked `subprocess`, MagicMock logger) covering the warning and the no-logger path.

---

Claude Code was used for implementation assistance. I've reviewed all changes myself and confirmed the behaviour locally.