### PR TITLE
Run Nethermind with production defaults

### DIFF
--- a/src/expb/clients/nethermind.py
+++ b/src/expb/clients/nethermind.py
@@ -38,17 +38,14 @@ class NethermindConfig(ClientConfig):
                 # Disable peering
                 "--Init.DiscoveryEnabled=false",
                 "--Network.MaxActivePeers=0",
-                # Suppress forced GC between blocks for stable benchmarks
-                "--Merge.SweepMemory=NoGC",
-                "--Merge.CompactMemory=No",
-                "--Merge.CollectionsPerDecommit=-1",
             ],
             prometheus_metrics_path="/metrics",
             sse_data_feed_path="/data/events",
-            default_env={
-                "DOTNET_TieredCompilation": "0",
-                "DOTNET_GCLatencyLevel": "0",
-            },
+            # No GC or code-generation overrides: the client must run the way it
+            # runs in production, or the benchmark measures a configuration nobody
+            # ships. Set them per scenario (extra_flags/extra_env) or per run
+            # (EXPB_CLIENT_ENV) when an experiment genuinely needs them.
+            default_env={},
             entrypoint="/nethermind/nethermind",
         )
 


### PR DESCRIPTION
## What

Removes the five benchmark-only overrides applied to every Nethermind container:

| setting | client default | expb set |
|---|---|---|
| `Merge.SweepMemory` | `Gen1` | `NoGC` |
| `Merge.CompactMemory` | `Yes` | `No` |
| `Merge.CollectionsPerDecommit` | `25` | `-1` |
| `DOTNET_TieredCompilation` | `1` | `0` |
| `DOTNET_GCLatencyLevel` | unset | `0` |

## Why

**The GC flags hide the regressions we most want to catch.** All three suppress the GC work the client does between Engine API calls. A change that allocates more costs a real node GC time between blocks and costs this benchmark nothing, so allocation regressions are invisible here by construction.

**The tiering pin meant no run ever measured production code generation.** `DOTNET_TieredCompilation=0` also disables dynamic PGO. Beyond being unrepresentative, it silently distorts any code-generation comparison: with tiering off, ReadyToRun code is never re-JITted, so an R2R build is measured entirely on R2R-quality code.

Measured on the reproducible-benchmarks runner, flat/realblocks, same images and payloads, only the tiering pin changed:

| arm | with pin | production default |
|---|---:|---:|
| baseline | 23.16 ms | **20.41 ms** |
| R2R build | 26.31 ms (+13.6%) | 20.94 ms (**+2.6%**) |

The pin costs the baseline ~12%, and it inflates the apparent R2R penalty five-fold. Every conclusion drawn from a code-generation A/B under the pin needs re-checking.

It also broke PGO profile collection outright: `DOTNET_WritePGOData` needs tier-0 instrumentation and Tier-1 recompilation, so with tiering off there is nothing to write and the runtime silently produces no profile.

## Notes for merging

- Absolute numbers move (baseline ~12% faster) — **cached master aggregates must be re-anchored**, or the first PR runs after this land will report a false regression against pre-change baselines.
- Variance is the reason these were originally added, so it is worth one master-vs-master run to price the CV change. The durable levers for variance are quiescence, warm-up and repetition rather than changing the client's behaviour.
- Scenarios that genuinely need the old behaviour can still set `extra_flags`/`extra_env`, and `EXPB_CLIENT_ENV` overrides per run.