### PR TITLE
Add dotTrace profiling-type selection and a dotnet-trace EventPipe sidecar

### DIFF
--- a/src/expb/execute_scenario.py
+++ b/src/expb/execute_scenario.py
@@ -83,6 +83,20 @@ def execute_scenario(
             help="Enable JetBrains dotTrace profiling. Auto-installs if needed. Snapshot saved to outputs directory.",
         ),
     ] = False,
+    dottrace_mode: Annotated[
+        str,
+        typer.Option(
+            "--dottrace-mode",
+            help="dotTrace profiling type: sampling (default), tracing, or timeline. Timeline snapshots cannot be converted to XML by Reporter.",
+        ),
+    ] = "sampling",
+    dotnet_trace: Annotated[
+        bool,
+        typer.Option(
+            "--dotnet-trace/--no-dotnet-trace",
+            help="Collect an EventPipe .nettrace via a host-side dotnet-trace listener. Standalone: cpu-sampling profile; alongside --dottrace: runtime events only (gc/contention/threading/exception) so the profilers do not double-sample.",
+        ),
+    ] = False,
     client_restart_retries: Annotated[
         int,
         typer.Option(
@@ -164,6 +178,8 @@ def execute_scenario(
                         client_metrics=client_metrics,
                         stable_cpu=stable_cpu,
                         dottrace=dottrace,
+                        dottrace_mode=dottrace_mode,
+                        dotnet_trace=dotnet_trace,
                         client_restart_retries=client_restart_retries,
                         reap_orphans=reap_orphans,
                     ),

--- a/src/expb/execute_scenarios.py
+++ b/src/expb/execute_scenarios.py
@@ -89,6 +89,20 @@ def execute_scenarios(
             help="Enable JetBrains dotTrace profiling. Auto-installs if needed. Snapshot saved to outputs directory.",
         ),
     ] = False,
+    dottrace_mode: Annotated[
+        str,
+        typer.Option(
+            "--dottrace-mode",
+            help="dotTrace profiling type: sampling (default), tracing, or timeline. Timeline snapshots cannot be converted to XML by Reporter.",
+        ),
+    ] = "sampling",
+    dotnet_trace: Annotated[
+        bool,
+        typer.Option(
+            "--dotnet-trace/--no-dotnet-trace",
+            help="Collect an EventPipe .nettrace via a host-side dotnet-trace listener. Standalone: cpu-sampling profile; alongside --dottrace: runtime events only (gc/contention/threading/exception) so the profilers do not double-sample.",
+        ),
+    ] = False,
     client_restart_retries: Annotated[
         int,
         typer.Option(
@@ -200,6 +214,8 @@ def execute_scenarios(
                                 client_metrics=client_metrics,
                                 stable_cpu=stable_cpu,
                                 dottrace=dottrace,
+                                dottrace_mode=dottrace_mode,
+                                dotnet_trace=dotnet_trace,
                                 client_restart_retries=client_restart_retries,
                                 reap_orphans=reap_orphans,
                             ),

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -4,7 +4,9 @@ import os
 import re
 import secrets
 import signal
+import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -65,9 +67,15 @@ class ExecutorExecuteOptions:
         client_metrics: bool = True,
         stable_cpu: bool = True,
         dottrace: bool = False,
+        dottrace_mode: str = "sampling",
+        dotnet_trace: bool = False,
         client_restart_retries: int = 0,
         reap_orphans: bool = False,
     ):
+        if dottrace_mode not in ("sampling", "tracing", "timeline"):
+            raise ValueError(
+                f"dottrace_mode must be sampling, tracing, or timeline, got '{dottrace_mode}'"
+            )
         self.collect_per_payload_metrics: bool = collect_per_payload_metrics
         self.print_logs_to_console: bool = print_logs_to_console
         self.per_payload_metrics_logs: bool = per_payload_metrics_logs
@@ -77,6 +85,8 @@ class ExecutorExecuteOptions:
         self.client_metrics: bool = client_metrics
         self.stable_cpu: bool = stable_cpu
         self.dottrace: bool = dottrace
+        self.dottrace_mode: str = dottrace_mode
+        self.dotnet_trace: bool = dotnet_trace
         if client_restart_retries < 0:
             raise ValueError(
                 f"client_restart_retries must be >= 0, got {client_restart_retries}"
@@ -96,6 +106,8 @@ class Executor:
         self.running_command_futures: list[Future] = []
         self.executor_pool: ThreadPoolExecutor | None = None
         self._dottrace_active: bool = False
+        self._dotnet_trace_process: subprocess.Popen | None = None
+        self._dotnet_trace_diag_dir: Path | None = None
 
     # Scenario Setup
     def prepare_directories(self) -> None:
@@ -307,6 +319,26 @@ class Executor:
     _DOTTRACE_CONTAINER_PATH = "/opt/dottrace"
     _DOTTRACE_OUTPUT_PATH = "/dottrace-output"
     _DOTTRACE_DEFAULT_INSTALL_PATH = "/opt/dottrace"
+    _DOTNET_TRACE_DEFAULT_INSTALL_PATH = "/opt/dotnet-trace"
+    _DOTNET_TRACE_OUTPUT_PATH = "/dotnet-trace-output"
+    _DOTNET_TRACE_DIAG_PATH = "/dotnet-trace-diag"
+
+    def _ensure_dotnet_trace_installed(self) -> str:
+        """Ensure the dotnet-trace global tool is installed, return the host path."""
+        path = self._DOTNET_TRACE_DEFAULT_INSTALL_PATH
+        binary = Path(path) / "dotnet-trace"
+        if binary.exists():
+            self.log.info("dotnet-trace found", path=path)
+            return path
+        self.log.info("dotnet-trace not found, installing", path=path)
+        subprocess.run(
+            ["dotnet", "tool", "install", "--tool-path", path, "dotnet-trace"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return path
 
     def _ensure_dottrace_installed(self) -> str:
         """Ensure dotTrace CLI tools are installed, return the host path."""
@@ -357,6 +389,8 @@ class Executor:
         pyroscope: Pyroscope | None = None,
         stop_signal: str | None = None,
         dottrace: bool = False,
+        dottrace_mode: str = "sampling",
+        dotnet_trace: bool = False,
         restart_retries: int = 0,
     ) -> Container:
         # Command
@@ -416,6 +450,7 @@ class Executor:
                 f"{self._DOTTRACE_CONTAINER_PATH}/dottrace",
                 "start",
                 "--framework=NetCore",
+                f"--profiling-type={dottrace_mode.capitalize()}",
                 f"--save-to={snapshot_file}",
                 "--propagate-exit-code",
                 *(["--use-api"] if use_api else []),
@@ -427,6 +462,72 @@ class Executor:
             self.log.info(
                 "dotTrace profiling enabled",
                 snapshot_output=str(dottrace_output_dir / trace_name),
+            )
+
+        # dotnet-trace (EventPipe) collection: a host-side listener the container's runtime
+        # connects to via DOTNET_DiagnosticPorts over a shared bind mount. Coexists with
+        # dotTrace (different channel: EventPipe vs the CLR profiling API). Alongside
+        # dotTrace it records runtime events only (gc/contention/threading/exception) so
+        # the two profilers do not double-sample CPU; standalone it captures cpu-sampling.
+        if dotnet_trace:
+            dotnet_trace_bin = (
+                Path(self._ensure_dotnet_trace_installed()) / "dotnet-trace"
+            )
+            dotnet_trace_dir = self.config.outputs_dir / "dotnet-trace"
+            dotnet_trace_dir.mkdir(parents=True, exist_ok=True)
+            # The socket must live at a SHORT path: unix domain socket paths are
+            # capped at ~107 chars and expb output dirs routinely exceed that.
+            self._dotnet_trace_diag_dir = Path(
+                tempfile.mkdtemp(prefix="expb-dt-", dir="/tmp")
+            )
+            diag_socket = self._dotnet_trace_diag_dir / "diag.sock"
+            nettrace_file = dotnet_trace_dir / f"{self.config.test_id}.nettrace"
+            capture_args = (
+                ["--clrevents", "gc+contention+threading+exception",
+                 "--clreventlevel", "informational"]
+                if dottrace
+                else ["--profile", "cpu-sampling"]
+            )
+            collect_log = (dotnet_trace_dir / "dotnet-trace-collect.log").open("ab")
+            # The listener must be up before the runtime starts: a connect-type
+            # nosuspend port that finds nobody listening records nothing.
+            self._dotnet_trace_process = subprocess.Popen(
+                [
+                    str(dotnet_trace_bin),
+                    "collect",
+                    "--diagnostic-port",
+                    str(diag_socket),
+                    "-o",
+                    str(nettrace_file),
+                    *capture_args,
+                ],
+                stdout=collect_log,
+                stderr=collect_log,
+            )
+            execution_container_volumes.append(
+                f"{self._dotnet_trace_diag_dir}:{self._DOTNET_TRACE_DIAG_PATH}:rw"
+            )
+            diag_ports_value = f"{self._DOTNET_TRACE_DIAG_PATH}/diag.sock,nosuspend"
+            if dottrace and dottrace_entrypoint is not None:
+                # Container-wide env would be inherited by the dotTrace CLI launcher —
+                # itself a .NET process — which then grabs the diagnostic-port connection
+                # and gets traced instead of the client. Scope the variable to the
+                # client only via an env(1) wrapper inside the launch chain.
+                separator = dottrace_entrypoint.index("--")
+                dottrace_entrypoint[separator + 1:separator + 1] = [
+                    "/usr/bin/env",
+                    f"DOTNET_DiagnosticPorts={diag_ports_value}",
+                ]
+            else:
+                if execution_container_environment is None:
+                    execution_container_environment = {}
+                execution_container_environment["DOTNET_DiagnosticPorts"] = (
+                    diag_ports_value
+                )
+            self.log.info(
+                "dotnet-trace collection enabled",
+                trace_output=str(nettrace_file),
+                capture=("clrevents" if dottrace else "cpu-sampling"),
             )
 
         # Run execution container
@@ -1209,6 +1310,22 @@ class Executor:
                             error=e,
                         )
 
+        if self._dotnet_trace_process is not None:
+            collector = self._dotnet_trace_process
+            self._dotnet_trace_process = None
+            try:
+                # SIGINT finalizes the .nettrace; the session usually ends on its own
+                # once the client runtime disconnects.
+                collector.send_signal(signal.SIGINT)
+                collector.wait(timeout=120)
+                self.log.info("dotnet-trace collection stopped")
+            except Exception as e:
+                collector.kill()
+                self.log.error("dotnet-trace collector did not stop cleanly", error=e)
+            if self._dotnet_trace_diag_dir is not None:
+                shutil.rmtree(self._dotnet_trace_diag_dir, ignore_errors=True)
+                self._dotnet_trace_diag_dir = None
+
         if print_logs_to_console and print_per_payload_metrics_table:
             self._print_per_payload_metrics_table(per_payload_metrics_rows)
 
@@ -1349,6 +1466,10 @@ class Executor:
                 else None,
             )
             dottrace_enabled = options.dottrace or self.config.dottrace
+            dottrace_mode = (
+                options.dottrace_mode if options.dottrace else self.config.dottrace_mode
+            )
+            dotnet_trace_enabled = options.dotnet_trace or self.config.dotnet_trace
             stop_signal = (
                 "SIGINT"
                 if self.config.execution_client_extra_commands or dottrace_enabled
@@ -1359,6 +1480,8 @@ class Executor:
                 pyroscope=alloy_pyroscope,
                 stop_signal=stop_signal,
                 dottrace=dottrace_enabled,
+                dottrace_mode=dottrace_mode,
+                dotnet_trace=dotnet_trace_enabled,
                 restart_retries=options.client_restart_retries,
             )
 

--- a/src/expb/payloads/executor/executor_config.py
+++ b/src/expb/payloads/executor/executor_config.py
@@ -48,6 +48,8 @@ class ExecutorConfig:
         cpu_max_frequency_khz: int | None = None,
         offline_cpus: list[int] | None = None,
         dottrace: bool = False,
+        dottrace_mode: str = "sampling",
+        dotnet_trace: bool = False,
     ) -> None:
         # Executor Basic config
         self.scenario_name: str = scenario.name or "default"
@@ -84,6 +86,12 @@ class ExecutorConfig:
         self.cpu_max_frequency_khz: int | None = cpu_max_frequency_khz
         self.offline_cpus: list[int] = offline_cpus or []
         self.dottrace: bool = dottrace
+        if dottrace_mode not in ("sampling", "tracing", "timeline"):
+            raise ValueError(
+                f"dottrace_mode must be sampling, tracing, or timeline, got '{dottrace_mode}'"
+            )
+        self.dottrace_mode: str = dottrace_mode
+        self.dotnet_trace: bool = dotnet_trace
         ## K6 script config
         self.k6_payloads_amount: int = scenario.payloads_amount
         self.k6_payloads_delay: float = scenario.payloads_delay


### PR DESCRIPTION
## Changes

- **`--dottrace-mode sampling|tracing|timeline`** — maps to the dotTrace CLI's `--profiling-type` on the wrapped entrypoint. Default stays `sampling`, so existing callers are unchanged. Flows through `ExecutorExecuteOptions` (CLI wins over scenario config) into `start_execution_client`. Timeline snapshots cannot be converted to XML by Reporter.exe; line-by-line is deliberately not offered — it needs PDBs the client docker images do not carry.
- **`--dotnet-trace`** — collects an EventPipe `.nettrace` via a host-side `dotnet-trace collect` listener that the container runtime connects to through `DOTNET_DiagnosticPorts` (nosuspend) over a bind mount; no in-container tooling required. Alongside `--dottrace` it records runtime events only (`gc+contention+threading+exception`) so the two profilers do not double-sample CPU; standalone it captures the `cpu-sampling` profile. The collector is SIGINT-finalized after the client container is torn down; output lands in `outputs/dotnet-trace/`.

Two integration constraints are handled explicitly (both bit us in validation runs):
- the diagnostic socket lives in a short `/tmp` mkdtemp — unix socket paths cap at ~107 chars and expb output dirs exceed that;
- with dotTrace active, `DOTNET_DiagnosticPorts` is scoped to the client via an `env(1)` wrapper inside the launch chain — container-wide env is inherited by the dotTrace CLI launcher (itself a .NET process), which otherwise steals the diagnostic-port connection and gets traced instead of the client.

## Validation

Verified on the reproducible-benchmarks runner against 200 fusaka payloads (nethermind master image): sampling and tracing both produce Reporter-convertible `.dtp`s (tracing measured at ~3.9x per-payload overhead — call counts usable, timings not); the sidecar `.nettrace` parses with TraceEvent and yields GC pause / lock-contention statistics for the client process.

Companion workflow PR in nethermind wires these flags into `run-expb-reproducible-benchmarks` (that PR requires this one merged for dottrace-enabled runs).