### PR TITLE
Point the dotnet-trace collector at a usable .NET runtime

### DIFF
--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -108,6 +108,7 @@ class Executor:
         self._dottrace_active: bool = False
         self._dotnet_trace_process: subprocess.Popen | None = None
         self._dotnet_trace_diag_dir: Path | None = None
+        self._dotnet_root_cache: str | None = None
 
     # Scenario Setup
     def prepare_directories(self) -> None:
@@ -323,12 +324,70 @@ class Executor:
     _DOTNET_TRACE_OUTPUT_PATH = "/dotnet-trace-output"
     _DOTNET_TRACE_DIAG_PATH = "/dotnet-trace-diag"
 
+    @staticmethod
+    def _is_dotnet_root(candidate: Path) -> bool:
+        """A DOTNET_ROOT is only usable if the apphost can find hostfxr under it."""
+        return (candidate / "host" / "fxr").is_dir()
+
+    def _dotnet_root(self) -> str | None:
+        """Locate a DOTNET_ROOT for the diagnostics tools, asking the muxer first.
+
+        The directory holding the `dotnet` on PATH is not the root: a distro's
+        dotnet-host package installs a real binary under /usr/bin while the runtime
+        lives elsewhere, so deriving the root from the executable yields one without
+        host/fxr and the apphost aborts with ".NET location: Not found".
+        """
+        if self._dotnet_root_cache is not None:
+            return self._dotnet_root_cache or None
+        self._dotnet_root_cache = ""
+        dotnet = shutil.which("dotnet")
+        if dotnet is not None:
+            try:
+                listing = subprocess.run(
+                    [dotnet, "--list-runtimes"],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+            except (OSError, subprocess.SubprocessError):
+                listing = None
+            if listing is not None and listing.returncode == 0:
+                for line in listing.stdout.splitlines():
+                    start = line.find("[")
+                    if start == -1 or not line.endswith("]"):
+                        continue
+                    # ".../shared/Microsoft.NETCore.App" -> the root above "shared"
+                    root = Path(line[start + 1:-1]).parent.parent
+                    if self._is_dotnet_root(root):
+                        self._dotnet_root_cache = str(root)
+                        return self._dotnet_root_cache
+        return None
+
+    def _dotnet_tool_env(self) -> dict[str, str]:
+        """Environment for launching a framework-dependent dotnet global tool.
+
+        `dotnet tool install` produces an apphost that resolves a shared runtime on
+        every start, so it needs DOTNET_ROOT wherever the default probe paths do not
+        cover the install, plus a major roll-forward when the host carries only a
+        runtime newer than the tool's target framework. The dotTrace CLI needs none of
+        this because its package ships native binaries.
+        """
+        env = os.environ.copy()
+        env.setdefault("DOTNET_ROLL_FORWARD", "Major")
+        if "DOTNET_ROOT" not in env:
+            root = self._dotnet_root()
+            if root is not None:
+                env["DOTNET_ROOT"] = root
+        return env
+
     def _ensure_dotnet_trace_installed(self) -> str:
         """Ensure the dotnet-trace global tool is installed, return the host path."""
         path = self._DOTNET_TRACE_DEFAULT_INSTALL_PATH
         binary = Path(path) / "dotnet-trace"
         if binary.exists():
-            self.log.info("dotnet-trace found", path=path)
+            self.log.info(
+                "dotnet-trace found", path=path, dotnet_root=self._dotnet_root()
+            )
             return path
         self.log.info("dotnet-trace not found, installing", path=path)
         subprocess.run(
@@ -503,7 +562,24 @@ class Executor:
                 ],
                 stdout=collect_log,
                 stderr=collect_log,
+                env=self._dotnet_tool_env(),
             )
+            # A collector that cannot start dies at once, leaving no .nettrace and no
+            # signal until somebody opens the artifact.
+            time.sleep(0.5)
+            if self._dotnet_trace_process.poll() is not None:
+                tail = (
+                    (dotnet_trace_dir / "dotnet-trace-collect.log")
+                    .read_text(errors="replace")
+                    .strip()
+                )
+                self.log.error(
+                    "dotnet-trace collector exited immediately, "
+                    "no .nettrace will be produced",
+                    returncode=self._dotnet_trace_process.returncode,
+                    collect_log=tail[-2000:],
+                )
+                self._dotnet_trace_process = None
             execution_container_volumes.append(
                 f"{self._dotnet_trace_diag_dir}:{self._DOTNET_TRACE_DIAG_PATH}:rw"
             )


### PR DESCRIPTION
## Problem

The EventPipe sidecar has never collected anything in CI. Every dotTrace-enabled EXPB run since it landed produced a 427-byte error log and no `.nettrace`, silently:

```
App: /opt/dotnet-trace/dotnet-trace   Architecture: arm64
App host version: 8.0.30   .NET location: Not found
Failed to resolve libhostfxr.so [not found]. Error code: 0x80008083
```

The collector is a framework-dependent apphost from `dotnet tool install`, so it resolves a shared runtime on every start. On the arm64 runner that resolution fails: `dotnet` is at `/usr/bin/dotnet` (a real binary from the distro's `dotnet-host` package) while the runtime lives under `/usr/local/share/dotnet`, so nothing in the default probe paths matches.

The dotTrace CLI is unaffected because its package ships native binaries rather than a managed apphost — which is why one profiler worked and the other didn't.

## Change

- Resolve `DOTNET_ROOT` by asking `dotnet --list-runtimes` where the shared framework lives and taking the directory above it, validating `host/fxr` before accepting a candidate. Deriving the root from the `dotnet` executable's own directory does not work, which is the trap here.
- `DOTNET_ROLL_FORWARD=Major` so the net8.0 apphost runs against the host's .NET 10 runtime.
- Report an immediate collector exit as an error instead of leaving it to be found when somebody opens the artifact weeks later, and log the resolved root.

## Verification

Runs on the arm64 runner, `dottrace=sampling`, flat/superblocks:

| run | result |
|---|---|
| 32518432984 (before) | no `.nettrace`, 427-byte error log |
| 32520297530 (fix) | **0.89MB `.nettrace`**, "Trace completed" |
| 32520930492 (final squashed branch) | **0.91MB `.nettrace`**, "Trace completed" |

Resolved root logged as `dotnet_root=/usr/local/share/dotnet`.

Analysed content of the collected trace (64.9s window): 16 GCs / 245.8ms total pause (0.38% of window, worst a blocking gen0 at 81.7ms), 1622 contention events / 483.1ms total wait with an 86ms maximum, 84 exceptions. So the channel now carries the GC and lock data it was built for.

`ruff check src/expb/` clean, `pytest -q` 38 passed.

## Note for runner provisioning

`/opt/dotnet-trace` was baked onto the box without a discoverable runtime beside it. This change works around that, but installing the runtime so `dotnet` resolves normally would make the workaround unnecessary.