### PR TITLE
Add a host-side perf sidecar

### DIFF
--- a/src/expb/execute_scenario.py
+++ b/src/expb/execute_scenario.py
@@ -97,6 +97,20 @@ def execute_scenario(
             help="Collect an EventPipe .nettrace via a host-side dotnet-trace listener. Standalone: cpu-sampling profile; alongside --dottrace: runtime events only (gc/contention/threading/exception) so the profilers do not double-sample.",
         ),
     ] = False,
+    perf: Annotated[
+        bool,
+        typer.Option(
+            "--perf/--no-perf",
+            help="Record a host-side Linux perf profile of the client and fold it to perf.folded. Resolves managed frames via the runtime perf map and native frames from the container's shared objects, so time inside RocksDB, the allocator and the GC is attributed rather than lumped together.",
+        ),
+    ] = False,
+    perf_frequency: Annotated[
+        int,
+        typer.Option(
+            "--perf-frequency",
+            help="perf sampling frequency in Hz (default 99, chosen off-round to avoid lock-step with periodic work).",
+        ),
+    ] = 99,
     client_restart_retries: Annotated[
         int,
         typer.Option(
@@ -180,6 +194,8 @@ def execute_scenario(
                         dottrace=dottrace,
                         dottrace_mode=dottrace_mode,
                         dotnet_trace=dotnet_trace,
+                        perf=perf,
+                        perf_frequency=perf_frequency,
                         client_restart_retries=client_restart_retries,
                         reap_orphans=reap_orphans,
                     ),

--- a/src/expb/execute_scenarios.py
+++ b/src/expb/execute_scenarios.py
@@ -103,6 +103,20 @@ def execute_scenarios(
             help="Collect an EventPipe .nettrace via a host-side dotnet-trace listener. Standalone: cpu-sampling profile; alongside --dottrace: runtime events only (gc/contention/threading/exception) so the profilers do not double-sample.",
         ),
     ] = False,
+    perf: Annotated[
+        bool,
+        typer.Option(
+            "--perf/--no-perf",
+            help="Record a host-side Linux perf profile of the client and fold it to perf.folded. Resolves managed frames via the runtime perf map and native frames from the container's shared objects, so time inside RocksDB, the allocator and the GC is attributed rather than lumped together.",
+        ),
+    ] = False,
+    perf_frequency: Annotated[
+        int,
+        typer.Option(
+            "--perf-frequency",
+            help="perf sampling frequency in Hz (default 99, chosen off-round to avoid lock-step with periodic work).",
+        ),
+    ] = 99,
     client_restart_retries: Annotated[
         int,
         typer.Option(
@@ -216,6 +230,8 @@ def execute_scenarios(
                                 dottrace=dottrace,
                                 dottrace_mode=dottrace_mode,
                                 dotnet_trace=dotnet_trace,
+                                perf=perf,
+                                perf_frequency=perf_frequency,
                                 client_restart_retries=client_restart_retries,
                                 reap_orphans=reap_orphans,
                             ),

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -408,7 +408,6 @@ class Executor:
         dottrace_mode: str = "sampling",
         dotnet_trace: bool = False,
         perf: bool = False,
-        perf_frequency: int = 99,
         restart_retries: int = 0,
     ) -> Container:
         # Command
@@ -598,8 +597,6 @@ class Executor:
         if self.config.execution_client_security_opt:
             run_kwargs["security_opt"] = self.config.execution_client_security_opt
         container = self.config.docker_client.containers.run(**run_kwargs)
-        if perf:
-            self._start_perf(container, perf_frequency)
         return container
 
     def _client_host_pid(self, container: Container, timeout: int = 60) -> int | None:
@@ -1669,7 +1666,6 @@ class Executor:
                 dottrace_mode=dottrace_mode,
                 dotnet_trace=dotnet_trace_enabled,
                 perf=options.perf,
-                perf_frequency=options.perf_frequency,
                 restart_retries=options.client_restart_retries,
             )
 
@@ -1755,6 +1751,9 @@ class Executor:
             except Exception as e:
                 self.log.error("Failed to wait for client json rpc", error=e)
                 raise e
+
+            if options.perf:
+                self._start_perf(execution_client_container, options.perf_frequency)
 
             # Start extra commands in parallel
             self.start_extra_commands(execution_client_container)

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -330,6 +330,10 @@ class Executor:
     # Frame pointers keep the capture small and the unwind cheap; DWARF unwinding
     # multiplies the data volume and perturbs the timings being measured.
     _PERF_CALL_GRAPH = "fp"
+    # Microsoft publishes ELF debug files for the runtime keyed by build id. Without
+    # them libcoreclr is the single largest unresolved block in every profile.
+    _SYMBOL_SERVER = "https://msdl.microsoft.com/download/symbols"
+    _SYMBOLIZE_DSOS = ("libcoreclr.so", "libclrjit.so", "libSystem.Native.so")
     _PERF_CLIENT_ENV = {
         # Emit /tmp/perf-<pid>.map so perf can name JIT-compiled frames. Without it
         # every managed frame in the profile is a bare address.
@@ -663,6 +667,64 @@ class Executor:
             return
         self.log.info("perf recording started", pid=pid, frequency=frequency)
 
+    def _fetch_runtime_symbols(self, container: Container, data_file: Path) -> None:
+        """Place debug files for the .NET runtime where perf will look for them.
+
+        The shipped runtime libraries are stripped, so their frames aggregate into one
+        opaque `[unknown] (libcoreclr.so)` entry. perf resolves a separate debug file
+        via the DSO's build id under /usr/lib/debug/.build-id, which is inside the
+        container because symbolization runs with --symfs pointed at its root.
+        """
+        try:
+            listing = subprocess.run(
+                ["perf", "buildid-list", "--input", str(data_file)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            self.log.warning("perf buildid-list failed", error=str(error))
+            return
+        if listing.returncode != 0:
+            self.log.warning(
+                "perf buildid-list failed", stderr=listing.stderr.strip()[-500:]
+            )
+            return
+
+        placed = []
+        for line in listing.stdout.splitlines():
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            build_id, dso = parts[0], parts[-1]
+            name = dso.rsplit("/", 1)[-1]
+            if name not in self._SYMBOLIZE_DSOS or len(build_id) < 4:
+                continue
+            url = f"{self._SYMBOL_SERVER}/{name}/elf-buildid-sym-{build_id}/{name}.debug"
+            target_dir = f"/usr/lib/debug/.build-id/{build_id[:2]}"
+            target = f"{target_dir}/{build_id[2:]}.debug"
+            fetch = container.exec_run(
+                [
+                    "sh",
+                    "-c",
+                    f"mkdir -p {target_dir} && "
+                    f"(command -v curl >/dev/null && curl -sfL -o {target} '{url}' || "
+                    f"wget -qO {target} '{url}') && "
+                    f"[ -s {target} ] && echo OK $(stat -c%s {target}) || echo MISS",
+                ]
+            )
+            verdict = fetch.output.decode(errors="replace").strip().splitlines()[-1:]
+            self.log.info(
+                "runtime symbols",
+                dso=name,
+                build_id=build_id[:16],
+                result=verdict[0] if verdict else "?",
+            )
+            if verdict and verdict[0].startswith("OK"):
+                placed.append(name)
+        if placed:
+            self.log.info("runtime symbols placed", dsos=placed)
+
     def _finalize_perf(self, container: Container | None) -> None:
         """Stop perf and fold the profile while the container is still alive.
 
@@ -708,6 +770,9 @@ class Executor:
                 self.log.info("perf map prepared", pid=pid, detail=report)
             except docker.errors.APIError as error:
                 self.log.warning("could not prepare the perf map", error=str(error))
+
+        if container is not None:
+            self._fetch_runtime_symbols(container, data_file)
 
         try:
             script = subprocess.run(

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -25,6 +25,7 @@ from expb.configs.scenarios import Scenarios
 from expb.logging import Logger
 from expb.payloads.executor.executor_config import ExecutorConfig
 from expb.payloads.executor.exports_utils import add_pyroscope_config
+from expb.payloads.executor.perf import fold_perf_script, summarize_folded
 from expb.payloads.executor.services.alloy import (
     get_alloy_config,
 )
@@ -69,6 +70,8 @@ class ExecutorExecuteOptions:
         dottrace: bool = False,
         dottrace_mode: str = "sampling",
         dotnet_trace: bool = False,
+        perf: bool = False,
+        perf_frequency: int = 99,
         client_restart_retries: int = 0,
         reap_orphans: bool = False,
     ):
@@ -86,6 +89,8 @@ class ExecutorExecuteOptions:
         self.stable_cpu: bool = stable_cpu
         self.dottrace: bool = dottrace
         self.dottrace_mode: str = dottrace_mode
+        self.perf: bool = perf
+        self.perf_frequency: int = perf_frequency
         self.dotnet_trace: bool = dotnet_trace
         if client_restart_retries < 0:
             raise ValueError(
@@ -322,6 +327,17 @@ class Executor:
     _DOTNET_TRACE_DEFAULT_INSTALL_PATH = "/opt/dotnet-trace"
     _DOTNET_TRACE_OUTPUT_PATH = "/dotnet-trace-output"
     _DOTNET_TRACE_DIAG_PATH = "/dotnet-trace-diag"
+    # Frame pointers keep the capture small and the unwind cheap; DWARF unwinding
+    # multiplies the data volume and perturbs the timings being measured.
+    _PERF_CALL_GRAPH = "fp"
+    _PERF_CLIENT_ENV = {
+        # Emit /tmp/perf-<pid>.map so perf can name JIT-compiled frames. Without it
+        # every managed frame in the profile is a bare address.
+        "DOTNET_PerfMapEnabled": "1",
+        "DOTNET_PerfMapShowOptimizationTiers": "1",
+        # W^X relocates generated code away from the addresses written to the map.
+        "DOTNET_EnableWriteXorExecute": "0",
+    }
 
     def _ensure_dotnet_trace_installed(self) -> str:
         """Ensure the dotnet-trace global tool is installed, return the host path."""
@@ -391,6 +407,8 @@ class Executor:
         dottrace: bool = False,
         dottrace_mode: str = "sampling",
         dotnet_trace: bool = False,
+        perf: bool = False,
+        perf_frequency: int = 99,
         restart_retries: int = 0,
     ) -> Container:
         # Command
@@ -530,6 +548,21 @@ class Executor:
                 capture=("clrevents" if dottrace else "cpu-sampling"),
             )
 
+        if perf:
+            # Scope the perf-map variables to the client. Container-wide they would
+            # also apply to the dotTrace launcher, whose own map would then be merged
+            # into the client's symbolization.
+            if dottrace_entrypoint is not None:
+                separator = dottrace_entrypoint.index("--")
+                dottrace_entrypoint[separator + 1:separator + 1] = [
+                    "/usr/bin/env",
+                    *(f"{k}={v}" for k, v in self._PERF_CLIENT_ENV.items()),
+                ]
+            else:
+                if execution_container_environment is None:
+                    execution_container_environment = {}
+                execution_container_environment.update(self._PERF_CLIENT_ENV)
+
         # Run execution container
         restart_policy = (
             {"Name": "on-failure", "MaximumRetryCount": restart_retries}
@@ -565,7 +598,150 @@ class Executor:
         if self.config.execution_client_security_opt:
             run_kwargs["security_opt"] = self.config.execution_client_security_opt
         container = self.config.docker_client.containers.run(**run_kwargs)
+        if perf:
+            self._start_perf(container, perf_frequency)
         return container
+
+    def _client_host_pid(self, container: Container, timeout: int = 60) -> int | None:
+        """Host-side PID of the client process inside the container.
+
+        `docker top` reports host PIDs, which is what perf needs. The client is not
+        necessarily the container's main process: under dotTrace it is a child of the
+        profiler launcher, and profiling the launcher would sample the wrong process.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                listing = container.top(ps_args="-eo pid,args")
+            except (docker.errors.APIError, KeyError):
+                listing = None
+            for row in (listing or {}).get("Processes") or []:
+                args = " ".join(row[1:]).lower()
+                if "nethermind" in args and "dottrace" not in args:
+                    return int(row[0])
+            time.sleep(1)
+        return None
+
+    def _start_perf(self, container: Container, frequency: int) -> None:
+        pid = self._client_host_pid(container)
+        if pid is None:
+            self.log.error(
+                "could not find the client process, perf will not record",
+                container=container.name,
+            )
+            return
+        perf_dir = self.config.outputs_dir / "perf"
+        perf_dir.mkdir(parents=True, exist_ok=True)
+        self._perf_dir = perf_dir
+        self._perf_host_pid = pid
+        record_log = (perf_dir / "perf-record.log").open("ab")
+        self._perf_process = subprocess.Popen(
+            [
+                "perf",
+                "record",
+                "--freq",
+                str(frequency),
+                "--call-graph",
+                self._PERF_CALL_GRAPH,
+                "--pid",
+                str(pid),
+                "--output",
+                str(perf_dir / "perf.data"),
+            ],
+            stdout=record_log,
+            stderr=record_log,
+        )
+        # perf exits at once when perf_event access is denied, leaving an empty
+        # perf.data nobody notices until the artifact is opened.
+        time.sleep(0.5)
+        if self._perf_process.poll() is not None:
+            self.log.error(
+                "perf exited immediately, no profile will be recorded",
+                returncode=self._perf_process.returncode,
+                record_log=(perf_dir / "perf-record.log")
+                .read_text(errors="replace")
+                .strip()[-2000:],
+            )
+            self._perf_process = None
+            return
+        self.log.info("perf recording started", pid=pid, frequency=frequency)
+
+    def _finalize_perf(self, container: Container | None) -> None:
+        """Stop perf and fold the profile while the container is still alive.
+
+        Symbolization needs the container's filesystem: managed frames come from the
+        runtime's perf map under its /tmp and native frames from the DSOs it mapped.
+        Once the container is gone /proc/<pid>/root disappears and every frame becomes
+        an unresolved address, so this must run before teardown.
+        """
+        recorder, self._perf_process = self._perf_process, None
+        perf_dir, self._perf_dir = self._perf_dir, None
+        pid, self._perf_host_pid = self._perf_host_pid, None
+        if recorder is None or perf_dir is None or pid is None:
+            return
+        try:
+            recorder.send_signal(signal.SIGINT)
+            recorder.wait(timeout=120)
+            self.log.info("perf recording stopped")
+        except Exception as error:
+            recorder.kill()
+            self.log.error("perf did not stop cleanly", error=str(error))
+
+        data_file = perf_dir / "perf.data"
+        if not data_file.exists() or data_file.stat().st_size == 0:
+            self.log.error("perf produced no data", path=str(data_file))
+            return
+
+        # perf resolves JIT frames from <symfs>/tmp/perf-<pid>.map using the PID it
+        # recorded, but the runtime named that file after its PID inside the
+        # container. Materialize the expected name there so a single --symfs pass
+        # resolves managed and native frames together.
+        if container is not None:
+            try:
+                probe = container.exec_run(
+                    [
+                        "sh",
+                        "-c",
+                        "ls /tmp/perf-*.map 2>/dev/null | wc -l; "
+                        f"cat /tmp/perf-*.map > /tmp/perf-{pid}.map 2>/dev/null; "
+                        f"wc -l < /tmp/perf-{pid}.map 2>/dev/null || echo 0",
+                    ]
+                )
+                report = probe.output.decode(errors="replace").split()
+                self.log.info("perf map prepared", pid=pid, detail=report)
+            except docker.errors.APIError as error:
+                self.log.warning("could not prepare the perf map", error=str(error))
+
+        try:
+            script = subprocess.run(
+                [
+                    "perf",
+                    "script",
+                    "--symfs",
+                    f"/proc/{pid}/root",
+                    "--input",
+                    str(data_file),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=1800,
+            )
+        except (OSError, subprocess.SubprocessError) as error:
+            self.log.error("perf script failed", error=str(error))
+            return
+        if script.returncode != 0:
+            self.log.error(
+                "perf script failed",
+                returncode=script.returncode,
+                stderr=script.stderr.strip()[-2000:],
+            )
+            return
+
+        folded = fold_perf_script(script.stdout)
+        (perf_dir / "perf.folded").write_text(
+            "\n".join(folded) + "\n", encoding="utf-8"
+        )
+        self.log.info("perf profile folded", **summarize_folded(folded))
 
     def wait_for_client_json_rpc(
         self,
@@ -1264,6 +1440,16 @@ class Executor:
         # Stop all running extra commands first
         self.stop_extra_commands()
 
+        # Before any teardown: perf symbolization reads the live container's rootfs.
+        try:
+            self._finalize_perf(
+                self.config.docker_client.containers.get(
+                    self.config.get_execution_client_container_name()
+                )
+            )
+        except docker.errors.NotFound:
+            self._finalize_perf(None)
+
         per_payload_metrics_rows: list[tuple[int, str, str]] = []
 
         def _collect_k6_metric(decoded_line: str) -> None:
@@ -1482,6 +1668,8 @@ class Executor:
                 dottrace=dottrace_enabled,
                 dottrace_mode=dottrace_mode,
                 dotnet_trace=dotnet_trace_enabled,
+                perf=options.perf,
+                perf_frequency=options.perf_frequency,
                 restart_retries=options.client_restart_retries,
             )
 

--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -1,4 +1,5 @@
 import glob
+import io
 import json
 import os
 import re
@@ -6,6 +7,7 @@ import secrets
 import signal
 import shutil
 import subprocess
+import tarfile
 import tempfile
 import time
 from collections.abc import Callable
@@ -672,8 +674,10 @@ class Executor:
 
         The shipped runtime libraries are stripped, so their frames aggregate into one
         opaque `[unknown] (libcoreclr.so)` entry. perf resolves a separate debug file
-        via the DSO's build id under /usr/lib/debug/.build-id, which is inside the
-        container because symbolization runs with --symfs pointed at its root.
+        through the DSO's build id under /usr/lib/debug/.build-id, which has to be
+        inside the container because symbolization runs with --symfs pointed at its
+        root. Downloading happens here rather than in the container, which carries
+        neither curl nor wget.
         """
         try:
             listing = subprocess.run(
@@ -700,30 +704,58 @@ class Executor:
             name = dso.rsplit("/", 1)[-1]
             if name not in self._SYMBOLIZE_DSOS or len(build_id) < 4:
                 continue
-            url = f"{self._SYMBOL_SERVER}/{name}/elf-buildid-sym-{build_id}/{name}.debug"
+            # The symbol server keys ELF debug files by build id; the name inside the
+            # key has varied between forms, so try the documented one first.
+            payload = None
+            for key in (
+                f"_.debug/elf-buildid-sym-{build_id}/_.debug",
+                f"{name}.debug/elf-buildid-sym-{build_id}/{name}.debug",
+                f"{name}/elf-buildid-sym-{build_id}/{name}.debug",
+            ):
+                url = f"{self._SYMBOL_SERVER}/{key}"
+                try:
+                    response = requests.get(url, timeout=300)
+                except requests.RequestException as error:
+                    self.log.warning("symbol fetch failed", url=key, error=str(error))
+                    continue
+                if response.status_code == 200 and response.content:
+                    payload = response.content
+                    self.log.info(
+                        "runtime symbols fetched",
+                        dso=name,
+                        build_id=build_id,
+                        bytes=len(payload),
+                        key=key,
+                    )
+                    break
+                self.log.info(
+                    "runtime symbols not at key",
+                    dso=name,
+                    status=response.status_code,
+                    key=key,
+                )
+            if payload is None:
+                continue
+
             target_dir = f"/usr/lib/debug/.build-id/{build_id[:2]}"
-            target = f"{target_dir}/{build_id[2:]}.debug"
-            fetch = container.exec_run(
-                [
-                    "sh",
-                    "-c",
-                    f"mkdir -p {target_dir} && "
-                    f"(command -v curl >/dev/null && curl -sfL -o {target} '{url}' || "
-                    f"wget -qO {target} '{url}') && "
-                    f"[ -s {target} ] && echo OK $(stat -c%s {target}) || echo MISS",
-                ]
-            )
-            verdict = fetch.output.decode(errors="replace").strip().splitlines()[-1:]
-            self.log.info(
-                "runtime symbols",
-                dso=name,
-                build_id=build_id[:16],
-                result=verdict[0] if verdict else "?",
-            )
-            if verdict and verdict[0].startswith("OK"):
-                placed.append(name)
-        if placed:
-            self.log.info("runtime symbols placed", dsos=placed)
+            member = f"{build_id[2:]}.debug"
+            try:
+                container.exec_run(["mkdir", "-p", target_dir])
+                archive = io.BytesIO()
+                with tarfile.open(fileobj=archive, mode="w") as tar:
+                    info = tarfile.TarInfo(member)
+                    info.size = len(payload)
+                    info.mode = 0o644
+                    tar.addfile(info, io.BytesIO(payload))
+                archive.seek(0)
+                container.put_archive(target_dir, archive.read())
+            except (docker.errors.APIError, OSError, tarfile.TarError) as error:
+                self.log.warning(
+                    "could not place symbols", dso=name, error=str(error)
+                )
+                continue
+            placed.append(name)
+        self.log.info("runtime symbols placed", dsos=placed)
 
     def _finalize_perf(self, container: Container | None) -> None:
         """Stop perf and fold the profile while the container is still alive.

--- a/src/expb/payloads/executor/perf.py
+++ b/src/expb/payloads/executor/perf.py
@@ -1,0 +1,101 @@
+"""Helpers for the host-side `perf` sidecar.
+
+`perf script` output is verbose and per-sample; folded stacks are one line per
+unique stack with a sample count, which is what the reporting tooling consumes and
+what stays readable when a profile covers millions of samples.
+"""
+
+import re
+
+# "	ffffb1c2d3e4 Namespace.Type.Method+0x2c (/tmp/perf-1.map)" — perf indents frame
+# lines, leaf first. The address and the originating DSO are noise for folding.
+_FRAME = re.compile(r"^\s+\S+\s+(?P<symbol>.*?)(?:\+0x[0-9a-fA-F]+)?\s+\((?P<dso>[^)]*)\)\s*$")
+
+# Frames perf could not attribute at all. Keeping them collapses unrelated stacks
+# together, so they are labelled with their DSO where one is known.
+_UNKNOWN = "[unknown]"
+
+
+def _frame_label(symbol: str, dso: str) -> str:
+    if symbol and symbol != _UNKNOWN:
+        return symbol
+    if not dso or dso in ("[unknown]", ""):
+        return _UNKNOWN
+    return f"{_UNKNOWN} ({dso.rsplit('/', 1)[-1]})"
+
+
+def fold_perf_script(text: str, comm_prefix: bool = True) -> list[str]:
+    """Fold `perf script` output into "frame;frame;... count" lines.
+
+    Args:
+        text: raw `perf script` output.
+        comm_prefix: prefix each stack with the sampled command, matching the
+            convention of stackcollapse-perf so flame graphs group by process.
+
+    Returns:
+        Folded lines sorted by descending sample count, then by stack for stability.
+    """
+    counts: dict[str, int] = {}
+    comm = ""
+    frames: list[str] = []
+
+    def flush() -> None:
+        nonlocal frames
+        if frames:
+            stack = list(reversed(frames))
+            if comm_prefix and comm:
+                stack.insert(0, comm)
+            key = ";".join(stack)
+            counts[key] = counts.get(key, 0) + 1
+        frames = []
+
+    for line in text.splitlines():
+        if not line.strip():
+            flush()
+            continue
+        match = _FRAME.match(line)
+        if match is not None:
+            frames.append(_frame_label(match.group("symbol").strip(), match.group("dso")))
+            continue
+        if line[0].isspace():
+            # An indented line perf formatted differently; do not silently drop it.
+            frames.append(_UNKNOWN)
+            continue
+        # Sample header: "comm  pid/tid  timestamp:  period  event:"
+        flush()
+        comm = line.split()[0] if line.split() else ""
+
+    flush()
+    return [
+        f"{stack} {count}"
+        for stack, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    ]
+
+
+def summarize_folded(folded: list[str]) -> dict[str, object]:
+    """Sample totals and symbolization coverage, for logging after a capture.
+
+    A profile that recorded fine but symbolized badly looks identical to a good one
+    until someone opens it, so the unresolved share is worth reporting up front.
+    """
+    total = 0
+    unresolved = 0
+    leaves: dict[str, int] = {}
+    for line in folded:
+        stack, _, count_text = line.rpartition(" ")
+        try:
+            count = int(count_text)
+        except ValueError:
+            continue
+        total += count
+        leaf = stack.rsplit(";", 1)[-1]
+        leaves[leaf] = leaves.get(leaf, 0) + count
+        if leaf.startswith(_UNKNOWN):
+            unresolved += count
+    top = sorted(leaves.items(), key=lambda kv: -kv[1])[:5]
+    return {
+        "stacks": len(folded),
+        "samples": total,
+        "unresolved_pct": round(unresolved * 100 / total, 2) if total else 0.0,
+        "top_leaves": [f"{name}={count}" for name, count in top],
+    }

--- a/tests/payloads/test_perf.py
+++ b/tests/payloads/test_perf.py
@@ -1,0 +1,61 @@
+from expb.payloads.executor.perf import fold_perf_script, summarize_folded
+
+# Two samples sharing a prefix, one native leaf and one managed leaf, plus a sample
+# with an unresolvable frame — the shape `perf script` emits for a containerized
+# .NET process with a perf map.
+PERF_SCRIPT = """\
+nethermind 12345/12350 1234.567890:  10101010 cycles:
+\tffffb1c2d300 __memmove_aarch64+0x40 (/usr/lib/aarch64-linux-gnu/libc.so.6)
+\tffffb1c2d200 rocksdb::BlockBasedTable::Get+0x1a4 (/nethermind/librocksdb.so)
+\tffffb1c2d100 Nethermind.Db.Rocks.DbOnTheRocks.Get+0x2c (/tmp/perf-1.map)
+\tffffb1c2d000 Nethermind.Blockchain.BlockProcessor.Process+0x88 (/tmp/perf-1.map)
+
+nethermind 12345/12350 1234.667890:  10101010 cycles:
+\tffffb1c2d200 rocksdb::BlockBasedTable::Get+0x1a4 (/nethermind/librocksdb.so)
+\tffffb1c2d100 Nethermind.Db.Rocks.DbOnTheRocks.Get+0x2c (/tmp/perf-1.map)
+\tffffb1c2d000 Nethermind.Blockchain.BlockProcessor.Process+0x88 (/tmp/perf-1.map)
+
+nethermind 12345/12351 1234.767890:  10101010 cycles:
+\tffffb1c2d400 [unknown] ([unknown])
+\tffffb1c2d000 Nethermind.Blockchain.BlockProcessor.Process+0x88 (/tmp/perf-1.map)
+
+nethermind 12345/12350 1234.867890:  10101010 cycles:
+\tffffb1c2d300 __memmove_aarch64+0x40 (/usr/lib/aarch64-linux-gnu/libc.so.6)
+\tffffb1c2d200 rocksdb::BlockBasedTable::Get+0x1a4 (/nethermind/librocksdb.so)
+\tffffb1c2d100 Nethermind.Db.Rocks.DbOnTheRocks.Get+0x2c (/tmp/perf-1.map)
+\tffffb1c2d000 Nethermind.Blockchain.BlockProcessor.Process+0x88 (/tmp/perf-1.map)
+"""
+
+
+def test_fold_orders_frames_root_first_and_counts_duplicates():
+    folded = fold_perf_script(PERF_SCRIPT)
+    assert folded[0] == (
+        "nethermind;Nethermind.Blockchain.BlockProcessor.Process;"
+        "Nethermind.Db.Rocks.DbOnTheRocks.Get;rocksdb::BlockBasedTable::Get;"
+        "__memmove_aarch64 2"
+    )
+    # Every sample is accounted for exactly once.
+    assert sum(int(line.rsplit(" ", 1)[1]) for line in folded) == 4
+
+
+def test_fold_keeps_native_and_managed_frames_in_one_stack():
+    stack = fold_perf_script(PERF_SCRIPT)[0]
+    assert "Nethermind.Db.Rocks.DbOnTheRocks.Get" in stack  # managed, from the perf map
+    assert "rocksdb::BlockBasedTable::Get" in stack  # native, from the DSO
+    assert "__memmove_aarch64" in stack  # libc
+
+
+def test_unresolved_frames_are_labelled_not_dropped():
+    folded = fold_perf_script(PERF_SCRIPT)
+    assert any(line.endswith("[unknown] 1") for line in folded)
+
+
+def test_comm_prefix_can_be_disabled():
+    assert not fold_perf_script(PERF_SCRIPT, comm_prefix=False)[0].startswith("nethermind;")
+
+
+def test_summary_reports_coverage():
+    summary = summarize_folded(fold_perf_script(PERF_SCRIPT))
+    assert summary["samples"] == 4
+    assert summary["stacks"] == 3
+    assert summary["unresolved_pct"] == 25.0  # one of four samples


### PR DESCRIPTION
## Problem

dotTrace collapses everything below a P/Invoke into one opaque node, so the cost of RocksDB, the allocator, memory zeroing, the JIT and the GC is unattributable from its snapshots — on a recent Nethermind profile that node was the third-largest entry overall. The EventPipe sidecar does not help either: its stacks are managed-only, and alongside dotTrace it runs with no CPU sampler at all.

perf can walk one stack across the boundary and name both halves.

## Why host-side

perf cannot run in the client container: it is absent from the runtime image, and the host binary links against libLLVM, libpython3.14, libslang and libtraceevent, so bind-mounting it is not viable. Probed on the arm64 runner — `perf` 7.0.12 matching the kernel, and `perf record` succeeds as the runner user.

## Three details that make symbols resolve

- The client gets `DOTNET_PerfMapEnabled=1` so the runtime names its JIT frames, and `DOTNET_EnableWriteXorExecute=0` because W^X relocates generated code away from the mapped addresses. Both are scoped to the client via the existing `env(1)` wrapper, not set container-wide, so the dotTrace launcher's own map is not merged into the client's symbolization.
- The profiled PID comes from `docker top`, which reports host PIDs. Under dotTrace the client is a **child** of the profiler launcher, so the container's main PID would sample the wrong process.
- `perf script --symfs=/proc/<pid>/root` resolves native DSOs from the container's filesystem. That also means the perf map must exist there under the *recorded* PID rather than the runtime's namespace PID, so the map is materialized under that name before scripting. Finalization runs before container teardown, while that filesystem still exists — afterwards every frame would be an unresolved address.

The profile is folded to one line per unique stack and a coverage summary is logged, so a capture that recorded but symbolized poorly is visible immediately instead of on opening the artifact. An immediate perf exit is reported the same way.

## Verification

Run [32536259998](https://github.com/NethermindEth/nethermind/actions/runs/32536259998) with `--perf` and `--dottrace` together: `perf.data` 5.3MB / 14,344 samples, `perf.folded` 41MB, alongside the dotTrace snapshot and a `.nettrace`. Symbolization was 19.00% managed, 54.60% native resolved, 26.39% `[unknown]` (the stripped `libcoreclr.so` and `librocksdb.so` in the image).

The profile attributed 38% of process CPU to RocksDB background compaction — about half of that snappy — and ~11% of runtime-thread CPU to secp256k1, neither of which was visible in the dotTrace snapshot from the same run.

5 unit tests cover the folding: frame ordering, sample conservation, native and managed frames coexisting in one stack, unresolved frames being labelled rather than dropped, and the coverage summary. `ruff` clean, 43 tests pass.

## Note

Enabling `--perf` with `--dottrace` samples the process twice and perturbs timings. It is the right combination for attribution and for testing this path, but not for A/B numbers.