### PR TITLE
Fix perf cleanup when profiling is disabled

### DIFF
--- a/src/expb/payloads/executor/executor.py
+++ b/src/expb/payloads/executor/executor.py
@@ -116,6 +116,9 @@ class Executor:
         self._dotnet_trace_process: subprocess.Popen | None = None
         self._dotnet_trace_diag_dir: Path | None = None
         self._dotnet_root_cache: str | None = None
+        self._perf_process: subprocess.Popen | None = None
+        self._perf_dir: Path | None = None
+        self._perf_host_pid: int | None = None
 
     # Scenario Setup
     def prepare_directories(self) -> None:

--- a/tests/payloads/test_perf.py
+++ b/tests/payloads/test_perf.py
@@ -1,3 +1,8 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from expb.payloads.executor.executor import Executor
 from expb.payloads.executor.perf import fold_perf_script, summarize_folded
 
 # Two samples sharing a prefix, one native leaf and one managed leaf, plus a sample
@@ -25,6 +30,40 @@ nethermind 12345/12350 1234.867890:  10101010 cycles:
 \tffffb1c2d100 Nethermind.Db.Rocks.DbOnTheRocks.Get+0x2c (/tmp/perf-1.map)
 \tffffb1c2d000 Nethermind.Blockchain.BlockProcessor.Process+0x88 (/tmp/perf-1.map)
 """
+
+
+def test_finalize_perf_before_start_is_a_noop():
+    executor = Executor(config=Mock(), logger=Mock())
+
+    executor._finalize_perf(None)
+
+    assert executor._perf_process is None
+    assert executor._perf_dir is None
+    assert executor._perf_host_pid is None
+
+
+def test_finalize_perf_after_start_failure_is_a_noop(tmp_path):
+    executor = Executor(config=Mock(outputs_dir=tmp_path), logger=Mock())
+
+    with (
+        patch.object(executor, "_client_host_pid", return_value=12345),
+        patch(
+            "expb.payloads.executor.executor.subprocess.Popen",
+            side_effect=OSError("perf unavailable"),
+        ),
+        pytest.raises(OSError, match="perf unavailable"),
+    ):
+        executor._start_perf(Mock(), frequency=99)
+
+    assert executor._perf_process is None
+    assert executor._perf_dir == tmp_path / "perf"
+    assert executor._perf_host_pid == 12345
+
+    executor._finalize_perf(None)
+
+    assert executor._perf_process is None
+    assert executor._perf_dir is None
+    assert executor._perf_host_pid is None
 
 
 def test_fold_orders_frames_root_first_and_counts_duplicates():


### PR DESCRIPTION
## Problem

EXPB cleanup always calls `_finalize_perf()`, but the perf lifecycle fields were only created after perf startup progressed. Ordinary benchmarks with perf disabled therefore completed payload execution and then crashed during cleanup with `AttributeError: 'Executor' object has no attribute '_perf_process'`.

## Changes

- Initialize all perf lifecycle fields in `Executor.__init__`.
- Add regressions for cleanup before perf starts and after partial perf startup fails.

## Testing

- `uv run pytest tests/payloads/test_perf.py -q` — 7 passed.
- `uv run pytest -q` — 45 passed, 6 deselected.